### PR TITLE
Fixes to work with BinDeps/Homebrew properly

### DIFF
--- a/src/AudioIO.jl
+++ b/src/AudioIO.jl
@@ -54,6 +54,8 @@ function render(node::AudioNode, input::AudioBuf, info::DeviceInfo)
     end
 end
 
+# Get binary dependencies loaded from BinDeps
+include( "../deps/deps.jl")
 include("nodes.jl")
 include("portaudio.jl")
 include("sndfile.jl")

--- a/src/portaudio.jl
+++ b/src/portaudio.jl
@@ -77,7 +77,7 @@ end
 
 function handle_status(err::PaError)
     if err != PA_NO_ERROR
-        msg = ccall((:Pa_GetErrorText, "libportaudio"),
+        msg = ccall((:Pa_GetErrorText, libportaudio),
                     Ptr{Cchar}, (PaError,), err)
         error("libportaudio: " * bytestring(msg))
     end
@@ -151,14 +151,14 @@ type PortAudioInterface <: AudioInterface
 end
 
 # some thin wrappers to portaudio calls
-get_device_info(i) = unsafe_load(ccall((:Pa_GetDeviceInfo, "libportaudio"),
+get_device_info(i) = unsafe_load(ccall((:Pa_GetDeviceInfo, libportaudio),
                                  Ptr{PaDeviceInfo}, (PaDeviceIndex,), i))
-get_host_api_info(i) = unsafe_load(ccall((:Pa_GetHostApiInfo, "libportaudio"),
+get_host_api_info(i) = unsafe_load(ccall((:Pa_GetHostApiInfo, libportaudio),
                                    Ptr{PaHostApiInfo}, (PaHostApiIndex,), i))
 
 function get_portaudio_devices()
     init_portaudio()
-    device_count = ccall((:Pa_GetDeviceCount, "libportaudio"), PaDeviceIndex, ())
+    device_count = ccall((:Pa_GetDeviceCount, libportaudio), PaDeviceIndex, ())
     pa_devices = [get_device_info(i) for i in 0:(device_count - 1)]
     [PortAudioInterface(bytestring(d.name),
                         bytestring(get_host_api_info(d.host_api).name),
@@ -174,7 +174,7 @@ function init_portaudio()
         @assert(libportaudio_shim != "", "Failed to find required library libportaudio_shim. Try re-running the package script using Pkg.build(\"AudioIO\"), then reloading with reload(\"AudioIO\")")
 
         info("Initializing PortAudio. Expect errors as we scan devices")
-        err = ccall((:Pa_Initialize, "libportaudio"), PaError, ())
+        err = ccall((:Pa_Initialize, libportaudio), PaError, ())
         handle_status(err)
         portaudio_inited = true
     end

--- a/src/sndfile.jl
+++ b/src/sndfile.jl
@@ -1,7 +1,5 @@
 export af_open, FilePlayer
 
-const sndfile = "libsndfile"
-
 const SFM_READ = int32(0x10)
 const SFM_WRITE = int32(0x20)
 
@@ -59,12 +57,12 @@ function af_open(path::String, mode::String = "r",
         end
     end
 
-    filePtr = ccall((:sf_open, sndfile), Ptr{Void},
+    filePtr = ccall((:sf_open, libsndfile), Ptr{Void},
                     (Ptr{Uint8}, Int32, Ptr{SF_INFO}),
                     path, file_mode, &sfinfo)
 
     if filePtr == C_NULL
-        errmsg = ccall((:sf_strerror, sndfile), Ptr{Uint8}, (Ptr{Void},), filePtr)
+        errmsg = ccall((:sf_strerror, libsndfile), Ptr{Uint8}, (Ptr{Void},), filePtr)
         error(bytestring(errmsg))
     end
 
@@ -72,7 +70,7 @@ function af_open(path::String, mode::String = "r",
 end
 
 function Base.close(file::AudioFile)
-    err = ccall((:sf_close, sndfile), Int32, (Ptr{Void},), file.filePtr)
+    err = ccall((:sf_close, libsndfile), Int32, (Ptr{Void},), file.filePtr)
     if err != 0
         error("Failed to close file")
     end
@@ -95,19 +93,19 @@ function Base.read(file::AudioFile, nframes::Integer, dtype::Type)
     end
 
     if dtype == Int16
-        nread = ccall((:sf_readf_short, sndfile), Int64,
+        nread = ccall((:sf_readf_short, libsndfile), Int64,
                         (Ptr{Void}, Ptr{Int16}, Int64),
                         file.filePtr, arr, nframes)
     elseif dtype == Int32
-        nread = ccall((:sf_readf_int, sndfile), Int64,
+        nread = ccall((:sf_readf_int, libsndfile), Int64,
                         (Ptr{Void}, Ptr{Int32}, Int64),
                         file.filePtr, arr, nframes)
     elseif dtype == Float32
-        nread = ccall((:sf_readf_float, sndfile), Int64,
+        nread = ccall((:sf_readf_float, libsndfile), Int64,
                         (Ptr{Void}, Ptr{Float32}, Int64),
                         file.filePtr, arr, nframes)
     elseif dtype == Float64
-        nread = ccall((:sf_readf_double, sndfile), Int64,
+        nread = ccall((:sf_readf_double, libsndfile), Int64,
                         (Ptr{Void}, Ptr{Float64}, Int64),
                         file.filePtr, arr, nframes)
     end
@@ -124,19 +122,19 @@ function Base.write{T}(file::AudioFile, frames::Array{T})
     nframes = int(length(frames) / file.sfinfo.channels)
 
     if T == Int16
-        return ccall((:sf_writef_short, sndfile), Int64,
+        return ccall((:sf_writef_short, libsndfile), Int64,
                         (Ptr{Void}, Ptr{Int16}, Int64),
                         file.filePtr, frames, nframes)
     elseif T == Int32
-        return ccall((:sf_writef_int, sndfile), Int64,
+        return ccall((:sf_writef_int, libsndfile), Int64,
                         (Ptr{Void}, Ptr{Int32}, Int64),
                         file.filePtr, frames, nframes)
     elseif T == Float32
-        return ccall((:sf_writef_float, sndfile), Int64,
+        return ccall((:sf_writef_float, libsndfile), Int64,
                         (Ptr{Void}, Ptr{Float32}, Int64),
                         file.filePtr, frames, nframes)
     elseif T == Float64
-        return ccall((:sf_writef_double, sndfile), Int64,
+        return ccall((:sf_writef_double, libsndfile), Int64,
                         (Ptr{Void}, Ptr{Float64}, Int64),
                         file.filePtr, frames, nframes)
     end


### PR DESCRIPTION
Use the auto-generated `deps/deps.jl` file which caches binary object locations.  This is what gets created from `Pkg.build()`.  Use those cached locations in your `ccall`'s, as we don't mess around with global linker search paths that much anymore, since caching the full path is a lot faster.

Note that since you're creating a little shim this won't work on OSX machines that don't have a compiler.  If you'd like to distribute binaries of your shim, (best-case scenario, write that in Julia as well, with the upcoming multithreading capabilities, if that turns out to be possible) I may be able to help you with that.
