### PR TITLE
Added support for playing a node specifying a sample rate

### DIFF
--- a/src/AudioIO.jl
+++ b/src/AudioIO.jl
@@ -80,6 +80,12 @@ function play(node::AudioNode)
     play(node, _stream)
 end
 
+# Stream not given, but sampling rate of the array is specified.
+function play(node::AudioNode, sample_rate::Integer)
+    stream = PortAudioStream(sample_rate)
+    play(node, stream)
+end
+
 function stop(node::AudioNode)
     node.active = false
     notify(node.end_cond)


### PR DESCRIPTION
This is the beginning of an implementation to fix #33. For now, I have just created a function that allows specifying a sample rate instead of having to instantiate a stream by hand (to be used with, e.g., array players that do not have any info on the sample rate). If there's nothing wrong with this approach, we could add a similar function specialized for `FilePlayer` nodes (in this case, we do not need a sample rate argument, as the information is included in the `AudioFile` type.
