### PR TITLE
fix constant addition

### DIFF
--- a/src/operators.jl
+++ b/src/operators.jl
@@ -13,4 +13,4 @@
 +(in1::AudioNode, in2::NullNode) = in1
 +(in1::NullNode, in2::AudioNode) = in2
 +(in1::AudioNode, in2::Real) = Offset(in1, in2)
-+(in1::Real, in2::AudioNode) = Offset(in1, in2)
++(in1::Real, in2::AudioNode) = Offset(in2, in1)


### PR DESCRIPTION
due to
julia> s = 1.0 + SinOsc()
ERROR: `convert` has no method matching convert(::Type{AudioNode{T<:AudioRenderer}}, ::Float64)
 in OffsetRenderer at /Users/goretkin/.julia/v0.3/AudioIO/src/nodes.jl:178
 in + at /Users/goretkin/.julia/v0.3/AudioIO/src/operators.jl:16
